### PR TITLE
update registry class and example

### DIFF
--- a/auto_identity/__init__.py
+++ b/auto_identity/__init__.py
@@ -18,9 +18,9 @@ from .key_management import (
     save_key)
 from .certificate_manager import CertificateManager
 from .registry import Registry
-from .utils import der_encode_signature_algorithm_oid
+from .utils import der_encode_signature_algorithm_oid, blake2b_256
 
-__version__ = '0.1.4'
+__version__ = '0.1.5'
 
 __all__ = [
     "generate_rsa_key_pair",
@@ -34,6 +34,7 @@ __all__ = [
     "key_to_pem",
     "CertificateManager",
     "der_encode_signature_algorithm_oid",
+    "blake2b_256",
     "Registry",
     "Keypair",
 ]

--- a/auto_identity/__init__.py
+++ b/auto_identity/__init__.py
@@ -20,7 +20,7 @@ from .certificate_manager import CertificateManager
 from .registry import Registry
 from .utils import der_encode_signature_algorithm_oid, blake2b_256
 
-__version__ = '0.1.5'
+__version__ = '0.1.6'
 
 __all__ = [
     "generate_rsa_key_pair",

--- a/auto_identity/certificate_manager.py
+++ b/auto_identity/certificate_manager.py
@@ -13,7 +13,7 @@ class CertificateManager:
 
     def __init__(self,  certificate=None, private_key=None):
         """
-        Initializes a certificate issuer.
+        Initializes a certificate manager.
 
         Args:
             certificate(Certificate): Certificate.
@@ -21,19 +21,6 @@ class CertificateManager:
         """
         self.private_key = private_key
         self.certificate = certificate
-
-    @staticmethod
-    def _to_common_name(subject_name):
-        """
-        Converts a subject name to a common name.
-
-        Args:
-            subject_name(str): Subject name for the certificate(common name).
-
-        Returns:
-            str: Common name.
-        """
-        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_name)])
 
     def _prepare_signing_params(self):
         """
@@ -50,100 +37,18 @@ class CertificateManager:
 
         raise ValueError("Unsupported key type for signing.")
 
-    def create_csr(self, subject_name):
+    @staticmethod
+    def _to_common_name(subject_name):
         """
-        Creates a Certificate Signing Request(CSR).
-
-        Args:
-            subject_name(str): Subject name for the CSR(common name).
-
-        Returns:
-            CertificateSigningRequest: Created X.509 CertificateSigningRequest.
-        """
-        signing_params = self._prepare_signing_params()
-        csr = x509.CertificateSigningRequestBuilder().subject_name(
-            x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_name)])
-        ).sign(**signing_params)
-
-        return csr
-
-    def issue_certificate(self, csr, validity_period_days=365):
-        """
-        Issues a certificate for Certificate Signing Request(CSR).
-
-        Args:
-            csr(CertificateSigningRequest): Certificate Signing Request.
-            issuer_certificate(Certificate): Issuer certificate.
-            issuer_private_key(PrivateKey): Private key to sign the certificate with .
-            validity_period_days(int, optional): Number of days the certificate is valid. Defaults to 365.
-
-        Returns:
-            Certificate: Created X.509 certificate.
-        """
-        if self.certificate is None:
-            raise ValueError("Certificate is not set.")
-        if self.private_key is None:
-            raise ValueError("Private key is not set.")
-
-        issuer_certificate = self.certificate
-
-        # Verify that the public key derived from the private key matches the one in the issuer's certificate
-        if not do_public_keys_match(issuer_certificate.public_key(), self.private_key.public_key()):
-            raise ValueError(
-                "Issuer certificate public key does not match the private key used for signing.")
-
-        signing_params = self._prepare_signing_params()
-
-        certificate = x509.CertificateBuilder().subject_name(
-            csr.subject,
-        ).issuer_name(
-            issuer_certificate.subject,
-        ).public_key(
-            csr.public_key(),
-        ).serial_number(
-            x509.random_serial_number(),
-        ).not_valid_before(
-            datetime.now(timezone.utc),
-        ).not_valid_after(
-            datetime.now(timezone.utc) + timedelta(days=validity_period_days),
-        ).sign(**signing_params)
-
-        return certificate
-
-    def self_issue_certificate(self, subject_name: str, validity_period_days=365):
-        """
-        Issues a self-signed certificate for the identity.
+        Converts a subject name to a common name.
 
         Args:
             subject_name(str): Subject name for the certificate(common name).
-            private_key(PrivateKey): Private key to sign the certificate with .
-            validity_period_days(int, optional): Number of days the certificate is valid. Defaults to 365.
 
         Returns:
-            Certificate: Created X.509 certificate.
+            str: Common name.
         """
-        if self.private_key is None:
-            raise ValueError("Private key is not set.")
-
-        signing_params = self._prepare_signing_params()
-        common_name = self._to_common_name(subject_name)
-
-        certificate = x509.CertificateBuilder().subject_name(
-            common_name,
-        ).issuer_name(
-            common_name,
-        ).public_key(
-            self.private_key.public_key(),
-        ).serial_number(
-            x509.random_serial_number(),
-        ).not_valid_before(
-            datetime.now(timezone.utc),
-        ).not_valid_after(
-            datetime.now(timezone.utc) + timedelta(days=validity_period_days),
-        ).sign(**signing_params)
-
-        self.certificate = certificate
-        return certificate
+        return x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_name)])
 
     @staticmethod
     def certificate_to_pem(certificate: x509.Certificate):
@@ -181,3 +86,136 @@ class CertificateManager:
             str: Common name of the certificate.
         """
         return certificate.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
+
+    @staticmethod
+    def create_csr(subject_name, uri: str = None):
+        """
+        Creates an unsigned Certificate Signing Request(CSR).
+
+        Args:
+            subject_name(str): Subject name for the CSR(common name).
+
+        Returns:
+            CertificateSigningRequestBuilder: Created X.509 CertificateSigningRequestBuilder.
+        """
+        common_name = x509.Name(
+            [x509.NameAttribute(NameOID.COMMON_NAME, subject_name)])
+
+        csr = x509.CertificateSigningRequestBuilder().subject_name(
+            common_name)
+        if uri:
+            csr = csr.add_extension(
+                x509.SubjectAlternativeName([x509.UniformResourceIdentifier(uri)]), critical=False)
+
+        return csr
+
+    def sign_csr(self, csr):
+        """
+        Signs a Certificate Signing Request(CSR).
+
+        Args:
+            csr(CertificateSigningRequest): Certificate Signing Request.
+
+        Returns:
+            CertificateSigningRequest: Created X.509 CertificateSigningRequest.
+        """
+        if self.private_key is None:
+            raise ValueError("Private key is not set.")
+
+        signing_params = self._prepare_signing_params()
+
+        return csr.sign(**signing_params)
+
+    def create_and_sign_csr(self, subject_name, uri: str = None):
+        """
+        Creates and signs a Certificate Signing Request(CSR).
+
+        Args:
+            subject_name(str): Subject name for the CSR(common name).
+
+        Returns:
+            CertificateSigningRequest: Created X.509 CertificateSigningRequest.
+        """
+        csr = self.create_csr(subject_name, uri)
+        return self.sign_csr(csr)
+
+    def issue_certificate(self, csr: x509.CertificateSigningRequest, validity_period_days=365):
+        """
+        Issues a certificate for Certificate Signing Request(CSR).
+
+        Args:
+            csr(CertificateSigningRequest): Certificate Signing Request.
+            issuer_certificate(Certificate): Issuer certificate.
+            issuer_private_key(PrivateKey): Private key to sign the certificate with .
+            validity_period_days(int, optional): Number of days the certificate is valid. Defaults to 365.
+
+        Returns:
+            Certificate: Created X.509 certificate.
+        """
+        if self.private_key is None:
+            raise ValueError("Private key is not set.")
+
+        if self.certificate is None:
+            issuer_name = csr.subject
+        else:
+            if not do_public_keys_match(self.certificate.public_key(), self.private_key.public_key()):
+                raise ValueError(
+                    "Issuer certificate public key does not match the private key used for signing.")
+            issuer_name = self.certificate.subject
+
+        # Prepare the certificate builder with information from the CSR
+        certificate_builder = x509.CertificateBuilder().subject_name(
+            csr.subject
+        ).issuer_name(
+            issuer_name
+        ).public_key(
+            csr.public_key()
+        ).serial_number(
+            x509.random_serial_number()
+        ).not_valid_before(
+            datetime.utcnow()
+        ).not_valid_after(
+            # Set the certificate's validity period
+            datetime.utcnow() + timedelta(days=validity_period_days)
+        )
+
+        # Copy all extensions from the CSR to the certificate
+        for extension in csr.extensions:
+            certificate_builder = certificate_builder.add_extension(
+                extension.value, extension.critical
+            )
+
+        return certificate_builder.sign(**self._prepare_signing_params())
+
+    def self_issue_certificate(self, subject_name: str, validity_period_days=365):
+        """
+        Issues a self-signed certificate for the identity.
+
+        Args:
+            subject_name(str): Subject name for the certificate(common name).
+            private_key(PrivateKey): Private key to sign the certificate with .
+            validity_period_days(int, optional): Number of days the certificate is valid. Defaults to 365.
+
+        Returns:
+            Certificate: Created X.509 certificate.
+        """
+        if self.private_key is None:
+            raise ValueError("Private key is not set.")
+
+        csr = self.sign_csr(self.create_csr(subject_name))
+        certificate = self.issue_certificate(csr, validity_period_days)
+
+        self.certificate = certificate
+        return certificate
+
+    def save_certificate(self, file_path: str):
+        """
+        Saves the certificate to a file.
+
+        Args:
+            file_path (str): Path to the file where the certificate should be saved.
+        """
+        certificate_data = self.certificate.public_bytes(
+            serialization.Encoding.PEM)
+        with open(file_path, "wb") as cert_file:
+            cert_file.write(certificate_data)

--- a/auto_identity/certificate_manager.py
+++ b/auto_identity/certificate_manager.py
@@ -207,8 +207,8 @@ class CertificateManager:
                 raise ValueError(
                     "Issuer certificate public key does not match the private key used for signing.")
             issuer_name = self.certificate.subject
-            auto_id = blake2b_256((self.get_subject_common_name(
-                issuer_name)+self.get_subject_common_name(csr.subject)).encode())
+            auto_id = blake2b_256((self.get_certificate_auto_id(
+                self.certificate).encode() + self.get_subject_common_name(csr.subject).encode()))
 
         # Prepare the certificate builder with information from the CSR
         certificate_builder = x509.CertificateBuilder().subject_name(

--- a/auto_identity/utils.py
+++ b/auto_identity/utils.py
@@ -1,4 +1,5 @@
 from cryptography.x509.oid import ObjectIdentifier
+from cryptography.hazmat.primitives import hashes
 from pyasn1.type import namedtype, univ
 from pyasn1.codec.der.encoder import encode
 
@@ -35,3 +36,19 @@ def der_encode_signature_algorithm_oid(oid: ObjectIdentifier):
 
     der_encoded_oid = encode(algorithm_identifier)
     return der_encoded_oid
+
+
+def blake2b_256(data: bytes) -> bytes:
+    """
+    Hashes the given data using BLAKE2b-256.
+
+    Args:
+        data (bytes): The data to be hashed.
+
+    Returns:
+        bytes: The BLAKE2b-256 hash of the data.
+
+    """
+    digest = hashes.Hash(hashes.BLAKE2b(32))
+    digest.update(data)
+    return digest.finalize()

--- a/auto_identity/utils.py
+++ b/auto_identity/utils.py
@@ -1,5 +1,5 @@
+from hashlib import blake2b
 from cryptography.x509.oid import ObjectIdentifier
-from cryptography.hazmat.primitives import hashes
 from pyasn1.type import namedtype, univ
 from pyasn1.codec.der.encoder import encode
 
@@ -49,6 +49,6 @@ def blake2b_256(data: bytes) -> bytes:
         bytes: The BLAKE2b-256 hash of the data.
 
     """
-    digest = hashes.Hash(hashes.BLAKE2b(32))
-    digest.update(data)
-    return digest.finalize()
+    hasher = blake2b(data, digest_size=32)
+
+    return hasher.digest()

--- a/examples/register_auto_id.py
+++ b/examples/register_auto_id.py
@@ -1,6 +1,6 @@
 import os
 from dotenv import load_dotenv
-from auto_identity import generate_ed25519_key_pair, self_issue_certificate, Registry, Keypair
+from auto_identity import generate_ed25519_key_pair, CertificateManager, Registry, Keypair
 
 
 # Configuration
@@ -18,7 +18,8 @@ def main():
     registry = Registry(rpc_url=RPC_URL, signer=keypair)
 
     keys = generate_ed25519_key_pair()
-    certificate = self_issue_certificate("test", private_key=keys[0])
+    cm = CertificateManager(private_key=keys[0])
+    certificate = cm.self_issue_certificate("test")
 
     # Attempt to register the certificate
     receipt = registry.register_auto_id(certificate)

--- a/examples/register_auto_id.py
+++ b/examples/register_auto_id.py
@@ -11,16 +11,10 @@ KEYPAIR_URI = os.getenv("KEYPAIR_URI")
 
 def register(certificate, registry, issuer_id=None):
     # Attempt to register the certificate
-    receipt = registry.register_auto_id(certificate, issuer_id)
+    receipt, identifer = registry.register_auto_id(certificate, issuer_id)
     if receipt.is_success:
-        for event in receipt.triggered_events:
-            event_data = event['event'].serialize()
-            print(event_data)
-            if event_data.get('event_id') == 'NewAutoIdRegistered':
-                auto_id_identifier = event_data['attributes']
-                print(
-                    f"New Auto Id registered with identifier: {auto_id_identifier}")
-                return auto_id_identifier
+        print(f"Registration successful. {identifer}")
+        return identifer
     else:
         print("Registration failed.")
 

--- a/examples/register_auto_id.py
+++ b/examples/register_auto_id.py
@@ -35,7 +35,11 @@ def main():
     user_cm = CertificateManager(private_key=user_keys[0])
     user_csr = user_cm.create_and_sign_csr("user")
     user_cert = self_issued_cm.issue_certificate(user_csr)
+    CertificateManager.pretty_print_certificate(user_cert)
     register_user = register(user_cert, registry, issuer_id)
+
+    print(
+        f"auto id from cert: {CertificateManager.get_certificate_auto_id(user_cert)}")
 
 
 if __name__ == "__main__":

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='auto-sdk',
-    version='0.1.4',
+    version='0.1.5',
     author='Autonomys',
     author_email='jeremy@subspace.network',
     url='https://github.com/subspace/auto-kit',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='auto-sdk',
-    version='0.1.5',
+    version='0.1.6',
     author='Autonomys',
     author_email='jeremy@subspace.network',
     url='https://github.com/subspace/auto-kit',

--- a/tests/auto_identity_tests/test_certificate_manager.py
+++ b/tests/auto_identity_tests/test_certificate_manager.py
@@ -102,7 +102,7 @@ def test_get_subject_common_name():
     certificate = self_issuer.self_issue_certificate("Test")
 
     # Retrieve the common name from the certificate
-    common_name = self_issuer.get_subject_common_name(certificate)
+    common_name = self_issuer.get_subject_common_name(certificate.subject)
 
     # Assert that the common name matches the provided subject name
     assert common_name == subject_name

--- a/tests/auto_identity_tests/test_certificate_manager.py
+++ b/tests/auto_identity_tests/test_certificate_manager.py
@@ -13,7 +13,7 @@ def test_create_csr():
     csr_creator = CertificateManager(private_key=private_key)
 
     # Call the create_csr function
-    csr = csr_creator.create_csr(subject_name)
+    csr = csr_creator.create_and_sign_csr(subject_name)
 
     # Assert that the CSR is not None
     assert csr is not None
@@ -43,7 +43,7 @@ def test_issue_certificate():
 
     csr_creator = CertificateManager(private_key=subject_private_key)
     # Call the create_csr function to generate a CSR
-    csr = csr_creator.create_csr(subject_name)
+    csr = csr_creator.create_and_sign_csr(subject_name)
 
     # Issue a certificate using the CSR
     certificate = issuer.issue_certificate(csr)

--- a/tests/auto_identity_tests/test_utils.py
+++ b/tests/auto_identity_tests/test_utils.py
@@ -1,7 +1,7 @@
 import pathlib
 from cryptography.hazmat.backends import default_backend
 from cryptography import x509
-from auto_identity import der_encode_signature_algorithm_oid
+from auto_identity import der_encode_signature_algorithm_oid, blake2b_256
 
 
 def test_der_encode_algorithm2():
@@ -22,3 +22,10 @@ def test_der_encode_algorithm2():
     # Compare the DER encoded OID with the result from tests in https://github.com/subspace/subspace/blob/d875a5aac35c1732eec61ce4359782eff58ff6fc/domains/pallets/auto-id/src/tests.rs#L127
     from_rust_implementation = "300d06092a864886f70d01010b0500"
     assert (der_encoded_oid.hex() == from_rust_implementation)
+
+
+def test_blake2b_256():
+    data = b"Hello, world!"
+    hash = blake2b_256(data)
+    expected_hash = "b5da441cfe72ae042ef4d2b17742907f675de4da57462d4c3609c2e2ed755970"
+    assert hash.hex() == expected_hash


### PR DESCRIPTION
## **Type**
enhancement, bug_fix


___

## **Description**
- Refactored CertificateManager to include new methods for CSR creation, signing, and certificate issuance.
- Introduced RegistrationResult NamedTuple in Registry to improve register_auto_id method's return type.
- Added utility function for BLAKE2b-256 hashing in utils.py.
- Updated example script to demonstrate new CertificateManager functionalities and registration process.
- Adjusted tests to align with the updated CertificateManager methods.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>certificate_manager.py</strong><dd><code>Enhancements and Refactoring in CertificateManager</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto_identity/certificate_manager.py
<li>Refactored CertificateManager initialization and added new utility <br>methods.<br> <li> Added methods for CSR creation, signing, and certificate issuance with <br>auto_id logic.<br> <li> Implemented methods for converting certificates to/from PEM format and <br>extracting common names and auto_ids.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/auto-kit/pull/10/files#diff-0e2656366ca8dc0f8c8ec293e4fdf39a5121b94bd079114d5e00ef7e18cb01b5">+185/-84</a></td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>registry.py</strong><dd><code>Registry Registration Logic Update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto_identity/registry.py
<li>Introduced RegistrationResult NamedTuple for register_auto_id method <br>return type.<br> <li> Updated register_auto_id to return RegistrationResult with receipt and <br>identifier.<br> <li> Added logic to extract identifier from event data upon successful <br>registration.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/auto-kit/pull/10/files#diff-fa8540263fd163a5d17fa6f86273c2b673deb3a33c4688300fc47b8ee354dcb8">+16/-43</a>&nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.py</strong><dd><code>Utility Function for BLAKE2b-256 Hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

auto_identity/utils.py
- Added blake2b_256 function for hashing data.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/auto-kit/pull/10/files#diff-ee966a27daa4d8a31dbabc46189b035bde15e28c8b417995af07636226e8c1a3">+17/-0</a>&nbsp; &nbsp; </td>
</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>register_auto_id.py</strong><dd><code>Updated Example with CertificateManager and Registration Logic</code></dd></summary>
<hr>

examples/register_auto_id.py
<li>Updated example to use CertificateManager for certificate issuance and <br>registration.<br> <li> Added logic to register user certificate with issuer_id.<br> <li> Demonstrated certificate registration and auto_id retrieval.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/auto-kit/pull/10/files#diff-d0d0673206358c4480e3c89335564f5eca0f87d14f394d1dcc0fd0f2f14534a5">+26/-12</a>&nbsp; </td>
</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_certificate_manager.py</strong><dd><code>Test Adjustments for CertificateManager Updates</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/auto_identity_tests/test_certificate_manager.py
<li>Updated tests to reflect changes in CertificateManager's CSR creation <br>and signing.


</details>
    

  </td>
  <td><a href="https://github.com/subspace/auto-kit/pull/10/files#diff-15d1c16b926251637124a079bd27debc628584c91ee321c43707ee334314112c">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>
</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

